### PR TITLE
Added firecheckout extension integration

### DIFF
--- a/app/code/community/Razorpay/Payments/etc/config.xml
+++ b/app/code/community/Razorpay/Payments/etc/config.xml
@@ -82,6 +82,15 @@
             </output_razorpay_redirect>
           </observers>
         </controller_action_postdispatch_firecheckout_index_saveOrder>
+        <controller_action_postdispatch_firecheckout_onecolumn_saveOrder>
+          <observers>
+            <output_razorpay_redirect>
+              <type>singleton</type>
+              <class>Razorpay_Payments_Model_Observer</class>
+              <method>output_razorpay_redirect</method>
+            </output_razorpay_redirect>
+          </observers>
+        </controller_action_postdispatch_firecheckout_onecolumn_saveOrder>
       </events>
     </global>
     <frontend>

--- a/app/code/community/Razorpay/Payments/etc/config.xml
+++ b/app/code/community/Razorpay/Payments/etc/config.xml
@@ -73,6 +73,15 @@
             </output_razorpay_redirect>
           </observers>
         </controller_action_postdispatch_checkout_onepage_saveOrder>
+        <controller_action_postdispatch_firecheckout_index_saveOrder>
+          <observers>
+            <output_razorpay_redirect>
+              <type>singleton</type>
+              <class>Razorpay_Payments_Model_Observer</class>
+              <method>output_razorpay_redirect</method>
+            </output_razorpay_redirect>
+          </observers>
+        </controller_action_postdispatch_firecheckout_index_saveOrder>
       </events>
     </global>
     <frontend>

--- a/app/design/frontend/base/default/layout/razorpay.xml
+++ b/app/design/frontend/base/default/layout/razorpay.xml
@@ -6,4 +6,11 @@
             </block>
         </reference>
     </checkout_onepage_review>
+    <firecheckout_index_index>
+        <reference name="content">
+            <block type="razorpay/iframe" name="razorpay.iframe" as="razorpay_iframe">
+                <action method="setBlockId"><block_id>razorpayiframe</block_id></action>
+            </block>
+        </reference>
+    </firecheckout_index_index>
 </layout>


### PR DESCRIPTION
Hi,

Firecheckout client-side is compatible with magento responses, so I just added
event listener and block to the layout.

[Firecheckout homepage](http://templates-master.com/magento-one-page-checkout.html)