### PR TITLE
Fixed bug in magento code

### DIFF
--- a/Controller/Payment/Order.php
+++ b/Controller/Payment/Order.php
@@ -31,8 +31,7 @@ class Order extends \Razorpay\Magento\Controller\BaseController
             $context,
             $customerSession,
             $checkoutSession,
-            $config,
-            $catalogSession
+            $config
         );
 
         $this->checkoutFactory = $checkoutFactory;


### PR DESCRIPTION
The parent::constructor had an additional parameter that needed to be fixed. 