### PR TITLE
Magento double order fix

### DIFF
--- a/app/code/community/Razorpay/Payments/controllers/CheckoutController.php
+++ b/app/code/community/Razorpay/Payments/controllers/CheckoutController.php
@@ -25,6 +25,14 @@ class Razorpay_Payments_CheckoutController extends Mage_Core_Controller_Front_Ac
         $order = Mage::getModel('sales/order');
         $order->loadByIncrementId($session->getLastRealOrderId());
 
+        $state = $order->getState();
+
+        if (($state === 'processing') or
+            ($state === 'canceled'))
+        {
+            Mage::throwException("This order cannot be paid for. It is in $state state.");
+        }
+
         $order->setState('new', true);
 
         $this->loadLayout();


### PR DESCRIPTION
If the order is in processing or canceled state, it cannot be paid for and therefore, an exception will be thrown. 