### PR TITLE
Magento 2.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Razorpay Magento 2.0 plugin for accepting payments.",
     "require": {
         "php": "~5.5.0|~5.6.0|^7.0",
-        "magento/framework": "~102.0.0",    //Magento 2.3 compatible
+        "magento/framework": "~102.0.0",
         "razorpay/razorpay": "2.*"
     },
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Razorpay Magento 2.0 plugin for accepting payments.",
     "require": {
         "php": "~5.5.0|~5.6.0|^7.0",
-        "magento/framework": "~100.0||~101.0",
+        "magento/framework": "~102.0.0",    //Magento 2.3 compatible
         "razorpay/razorpay": "2.*"
     },
     "keywords": [


### PR DESCRIPTION
Changing the framework version to "~102.0.0" makes Razorpay compatible with Magento. 
This resolves issue #123 & #125