### PR TITLE
Disable module on Multi-Shipping Checkout

### DIFF
--- a/etc/payment.xml
+++ b/etc/payment.xml
@@ -3,7 +3,7 @@
          xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/payment.xsd">
     <methods>
         <method name="razorpay">
-            <allow_multiple_address>1</allow_multiple_address>
+            <allow_multiple_address>0</allow_multiple_address>          //Disable Multi-shipping
         </method>
     </methods>
 </payment>

--- a/etc/payment.xml
+++ b/etc/payment.xml
@@ -3,7 +3,7 @@
          xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/payment.xsd">
     <methods>
         <method name="razorpay">
-            <allow_multiple_address>0</allow_multiple_address>          //Disable Multi-shipping
+            <allow_multiple_address>0</allow_multiple_address>
         </method>
     </methods>
 </payment>


### PR DESCRIPTION
Magento ``MultishippingController`` does not support Redirect URL for payment gateways. Therefore, multi-shipping needs to be disabled here
This resolves issue #61