### PR TITLE
Disable module for Magento Admin Order

### DIFF
--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -48,7 +48,7 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
     /**
      * @var bool
      */
-    protected $_canUseInternal          = true;
+    protected $_canUseInternal          = false;        //Disable module for Magento Admin Order
 
     /**
      * @var bool


### PR DESCRIPTION
Magento does not support redirect URL for payment gateways in admin order. 
Also, in theory, the client’s transactional data is unavailable to the admin. Thus the logical solution is only to have offline payment modes for the admin.
This resolves issue #115