### PR TITLE
Pass the Payment Action value to Razorpay

### DIFF
--- a/Controller/Payment/Order.php
+++ b/Controller/Payment/Order.php
@@ -36,6 +36,7 @@ class Order extends \Razorpay\Magento\Controller\BaseController
 
         $this->checkoutFactory = $checkoutFactory;
         $this->catalogSession = $catalogSession;
+	$this->config = $config;
     }
 
     public function execute()
@@ -43,6 +44,15 @@ class Order extends \Razorpay\Magento\Controller\BaseController
         $amount = (int) (round($this->getQuote()->getBaseGrandTotal(), 2) * 100);
 
         $receipt_id = $this->getQuote()->getId();
+	    
+	$payment_action = $this->config->getPaymentAction();
+	    
+	if($payment_action == "authorize") {
+		$payment_capture = 0;
+	}
+	else { 
+		$payment_capture = 1;
+	}    
 
         $code = 400;
 
@@ -52,7 +62,7 @@ class Order extends \Razorpay\Magento\Controller\BaseController
                 'amount' => $amount,
                 'receipt' => $receipt_id,
                 'currency' => $this->_currency,
-                'payment_capture' => 1                 // auto-capture
+                'payment_capture' => $payment_capture
             ]);
 
             $responseContent = [

--- a/Controller/Payment/Order.php
+++ b/Controller/Payment/Order.php
@@ -44,15 +44,14 @@ class Order extends \Razorpay\Magento\Controller\BaseController
         $amount = (int) (round($this->getQuote()->getBaseGrandTotal(), 2) * 100);
 
         $receipt_id = $this->getQuote()->getId();
-	    
-	$payment_action = $this->config->getPaymentAction();
-	    
-	if($payment_action == "authorize") {
-		$payment_capture = 0;
+
+        $payment_action = $this->config->getPaymentAction();
+
+        if($payment_action == "authorize") {
+                $payment_capture = 0;
+        } else { 
+                $payment_capture = 1;
 	}
-	else { 
-		$payment_capture = 1;
-	}    
 
         $code = 400;
 

--- a/Controller/Payment/Order.php
+++ b/Controller/Payment/Order.php
@@ -36,7 +36,7 @@ class Order extends \Razorpay\Magento\Controller\BaseController
 
         $this->checkoutFactory = $checkoutFactory;
         $this->catalogSession = $catalogSession;
-	$this->config = $config;
+        $this->config = $config;
     }
 
     public function execute()
@@ -47,11 +47,14 @@ class Order extends \Razorpay\Magento\Controller\BaseController
 
         $payment_action = $this->config->getPaymentAction();
 
-        if($payment_action == "authorize") {
+        if ($payment_action === 'authorize') 
+        {
                 $payment_capture = 0;
-        } else { 
+        }
+        else
+        {
                 $payment_capture = 1;
-	}
+        }
 
         $code = 400;
 


### PR DESCRIPTION
Get the value of payment action configured by the admin `$payment_action`.
Set `$payment_capture` = 0 for "Authorize only" and 1 for "Authorize and Capture".