### PR TITLE
removed magento framework dependency for magento 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "version": "2.7.0",
     "require": {
         "php": "~5.5.0|~5.6.0|^7.0",
-        "magento/framework": "~102.0.0",
         "razorpay/razorpay": "2.*"
     },
     "keywords": [


### PR DESCRIPTION
Removed magento framework dependency for magento 2.x, as we already installing this module for top of magento2.x.

