### PR TITLE
Mage2.3.5 csp implementation patch 1

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="img-src">
+            <values>
+                <value id="razorpay_cdn" type="host">cdn.razorpay.com</value>
+            </values>
+        </policy>
+        <policy id="script-src">
+            <values>
+                <value id="razorpay_checkout" type="host">checkout.razorpay.com</value>
+            </values>
+        </policy>
+        <policy id="frame-src">
+            <values>
+                <value id="razorpay_api" type="host">api.razorpay.com</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
This file will allow razorpay urls valid and accessible when using Magento 2.3.5 which have Content security Policy implementation.