### PR TITLE
PON-542:  Webhook orders missing original_price for orders items.

### DIFF
--- a/Controller/Payment/Webhook.php
+++ b/Controller/Payment/Webhook.php
@@ -309,6 +309,8 @@ class Webhook extends \Razorpay\Magento\Controller\BaseController
 
         $quote->setStore($store);
 
+        $quote->collectTotals();
+
         $quote->save();
 
         return $quote;


### PR DESCRIPTION
Order created with webhooks, missing the Original Price in order view details page. 