### PR TITLE
GraphQL addition

### DIFF
--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -225,21 +225,110 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
             }
             else
             {
-                $payment_id = $request['paymentMethod']['additional_data']['rzp_payment_id'];
-
-                $rzp_order_id = $this->order->getOrderId();
-
-                //validate RzpOrderamount with quote/order amount before signature
-                $orderAmount = (int) (number_format($order->getGrandTotal() * 100, 0, ".", ""));
-
-                if ($orderAmount !== $this->order->getRazorpayOrderAmount())
+                //check for GraphQL
+                if(empty($request['query']) === false)
                 {
-                    $rzpOrderAmount = $order->getOrderCurrency()->formatTxt(number_format($this->order->getRazorpayOrderAmount() / 100, 2, ".", ""));
 
-                    throw new LocalizedException(__("Cart order amount = %1 doesn't match with amount paid = %2", $order->getOrderCurrency()->formatTxt($order->getGrandTotal()), $rzpOrderAmount));
+                    //update orderLink
+                    $_objectManager  = \Magento\Framework\App\ObjectManager::getInstance();
+
+                    $orderLinkCollection = $_objectManager->get('Razorpay\Magento\Model\OrderLink')
+                                                               ->getCollection()
+                                                               ->addFilter('quote_id', $order->getQuoteId())
+                                                               ->getFirstItem();
+
+                    $orderLink = $orderLinkCollection->getData();
+
+                    if (empty($orderLink['entity_id']) === false)
+                    {
+                        $payment_id = $orderLink['rzp_payment_id'];
+
+                        $rzp_order_id = $orderLink['rzp_order_id'];
+
+                        if((empty($payment_id) === true) and
+                           (emprty($rzp_order_id) === true))
+                        {
+                            throw new LocalizedException(__("Razorpay Payment details missing."));
+                        }
+
+                        try
+                        {
+                            //fetch the payment from API and validate the amount
+                            $payment_data = $this->rzp->payment->fetch($payment_id);
+                        }
+                        catch(\Razorpay\Api\Errors\Error $e)
+                        {
+                           $this->_logger->critical($e);
+                           throw new LocalizedException(__('Razorpay Error: %1.', $e->getMessage()));
+                        }
+
+                        if(($payment_data->order_id === $rzp_order_id) and
+                           ($payment_data->status === 'captured'))
+                        {
+                            try
+                            {
+                                //fetch order from API
+                                $rzp_order_data = $this->rzp->order->fetch($rzp_order_id);
+                            }
+                            catch(\Razorpay\Api\Errors\Error $e)
+                            {
+                               $this->_logger->critical($e);
+                               throw new LocalizedException(__('Razorpay Error: %1.', $e->getMessage()));
+                            }
+
+                            //verify order receipt
+                            if($rzp_order_data->receipt !== $order->getQuoteId())
+                            {
+                                throw new LocalizedException(__("Not a valid Razorpay Payment"));
+                            }
+
+                            //verify currency
+                            if($payment_data->currency !== $order->getOrderCurrencyCode())
+                            {
+                                throw new LocalizedException(__("Order Currency:(%1) not matched with payment currency:(%2)", $order->getOrderCurrencyCode(), $payment_data->currency));
+                            }
+
+                            $orderAmount = (int) (number_format($order->getGrandTotal() * 100, 0, ".", ""));
+
+                            if($orderAmount !== $payment_data->amount)
+                            {
+                                 $rzpOrderAmount = $order->getOrderCurrency()->formatTxt(number_format($payment_data->amount / 100, 2, ".", ""));
+
+                                throw new LocalizedException(__("Cart order amount = %1 doesn't match with amount paid = %2", $order->getOrderCurrency()->formatTxt($order->getGrandTotal()), $rzpOrderAmount));
+                            }
+                        }
+                        else
+                        {
+                            throw new LocalizedException(__("Not a valid Razorpay Payments."));
+                        }
+
+                    }
+                    else
+                    {
+                        throw new LocalizedException(__("Razorpay Payment details missing."));
+                    }
                 }
+                else
+                {
+                    // Order processing through front-end
 
-                $this->validateSignature($request);
+                    $payment_id = $request['paymentMethod']['additional_data']['rzp_payment_id'];
+
+                    $rzp_order_id = $this->order->getOrderId();
+
+                    //validate RzpOrderamount with quote/order amount before signature
+                    $orderAmount = (int) (number_format($order->getGrandTotal() * 100, 0, ".", ""));
+
+                    if ($orderAmount !== $this->order->getRazorpayOrderAmount())
+                    {
+                        $rzpOrderAmount = $order->getOrderCurrency()->formatTxt(number_format($this->order->getRazorpayOrderAmount() / 100, 2, ".", ""));
+
+                        $abcAmount = $order->getGrandTotal();
+                        throw new LocalizedException(__("Cart order amount = %1 doesn't match with amount paid = %2", $order->getOrderCurrency()->formatTxt($order->getGrandTotal()), $rzpOrderAmount));
+                    }
+
+                    $this->validateSignature($request);
+                }
             }
 
             $payment->setStatus(self::STATUS_APPROVED)

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -296,15 +296,6 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
                             {
                                 throw new LocalizedException(__("Order Currency:(%1) not matched with payment currency:(%2)", $order->getOrderCurrencyCode(), $payment_data->currency));
                             }
-
-                            $orderAmount = (int) (number_format($order->getGrandTotal() * 100, 0, ".", ""));
-
-                            if($orderAmount !== $payment_data->amount)
-                            {
-                                 $rzpOrderAmount = $order->getOrderCurrency()->formatTxt(number_format($payment_data->amount / 100, 2, ".", ""));
-
-                                throw new LocalizedException(__("Cart order amount = %1 doesn't match with amount paid = %2", $order->getOrderCurrency()->formatTxt($order->getGrandTotal()), $rzpOrderAmount));
-                            }
                         }
                         else
                         {

--- a/Model/Resolver/PlaceRazorpayOrder.php
+++ b/Model/Resolver/PlaceRazorpayOrder.php
@@ -47,9 +47,6 @@ class PlaceRazorpayOrder implements ResolverInterface
         try
         {
             $storeScope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
-            //$key        = $this->scopeConfig->getValue('payment/razorpay/key_id', $storeScope);
-            //$key_secret = $this->scopeConfig->getValue('payment/razorpay/key_secret', $storeScope);
-            //$this->rzp  = new Api($key, $key_secret);
 
             $storeId = (int) $context->getExtensionAttributes()->getStore()->getId();
 
@@ -100,6 +97,7 @@ class PlaceRazorpayOrder implements ResolverInterface
                 if (empty($orderLinkData['entity_id']) === false)
                 {
                     $orderLinkCollection->setRzpOrderId($order->id)
+                                        ->setRzpOrderAmount($amount)
                                         ->save();
                 }
                 else
@@ -107,6 +105,7 @@ class PlaceRazorpayOrder implements ResolverInterface
                     $orderLink = $this->_objectManager->create('Razorpay\Magento\Model\OrderLink');
                     $orderLink->setQuoteId($receipt_id)
                             ->setRzpOrderId($order->id)
+                            ->setRzpOrderAmount($amount)
                             ->save();
                 }
 

--- a/Model/Resolver/PlaceRazorpayOrder.php
+++ b/Model/Resolver/PlaceRazorpayOrder.php
@@ -1,0 +1,138 @@
+<?php
+declare (strict_types = 1);
+
+namespace Razorpay\Magento\Model\Resolver;
+
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
+use Magento\Quote\Api\CartManagementInterface;
+use Razorpay\Magento\Model\PaymentMethod;
+
+class PlaceRazorpayOrder implements ResolverInterface
+{
+
+    protected $scopeConfig;
+
+    protected $cartManagement;
+
+    protected $_objectManager;
+
+    public function __construct(
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        GetCartForUser $getCartForUser,
+        \Magento\Quote\Api\CartManagementInterface $cartManagement,
+        PaymentMethod $paymentMethod
+    ) {
+        $this->scopeConfig    = $scopeConfig;
+        $this->getCartForUser = $getCartForUser;
+        $this->cartManagement = $cartManagement;
+        $this->rzp = $paymentMethod->rzp;
+        $this->_objectManager   = \Magento\Framework\App\ObjectManager::getInstance();
+    }
+
+    /**
+     * @param GetCartForUser $getCartForUser
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (empty($args['cart_id'])) {
+            throw new GraphQlInputException(__('Required parameter "cart_id" is missing'));
+        }
+
+        try
+        {
+            $storeScope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
+            //$key        = $this->scopeConfig->getValue('payment/razorpay/key_id', $storeScope);
+            //$key_secret = $this->scopeConfig->getValue('payment/razorpay/key_secret', $storeScope);
+            //$this->rzp  = new Api($key, $key_secret);
+
+            $storeId = (int) $context->getExtensionAttributes()->getStore()->getId();
+
+            $maskedCartId = $args['cart_id'];
+
+            $cart            = $this->getCartForUser->execute($maskedCartId, $context->getUserId(), $storeId);
+            $receipt_id      = $cart->getId();
+            $amount          = (int) (number_format($cart->getGrandTotal() * 100, 0, ".", ""));
+            $payment_action  = $this->scopeConfig->getValue('payment/razorpay/payment_action', $storeScope);
+            
+            $payment_capture = 1;
+            
+            if ($payment_action === 'authorize')
+            {
+                $payment_capture = 0;
+            }
+
+            $order = $this->rzp->order->create([
+                'amount'          => $amount,
+                'receipt'         => $receipt_id,
+                'currency'        => $cart->getQuoteCurrencyCode(),
+                'payment_capture' => $payment_capture,
+                'app_offer'       => (($cart->getBaseSubtotal() - $cart->getBaseSubtotalWithDiscount()) > 0) ? 1 : 0,
+            ]);
+
+            if (null !== $order && !empty($order->id))
+            {
+
+                $responseContent = [
+                    'success'        => true,
+                    'rzp_order_id'   => $order->id,
+                    'order_quote_id' => $receipt_id,
+                    'amount'         => number_format((float) $cart->getGrandTotal(), 2, ".", ""),
+                    'currency'       => $cart->getQuoteCurrencyCode(),
+                    'message'        => 'Razorpay Order created successfully'
+                ];
+                
+
+                //save to razorpay orderLink
+                $orderLinkCollection = $this->_objectManager
+                    ->get('Razorpay\Magento\Model\OrderLink')
+                    ->getCollection()
+                    ->addFilter('quote_id', $receipt_id)
+                    ->getFirstItem();
+
+                $orderLinkData = $orderLinkCollection->getData();
+
+                if (empty($orderLinkData['entity_id']) === false)
+                {
+                    $orderLinkCollection->setRzpOrderId($order->id)
+                                        ->save();
+                }
+                else
+                {
+                    $orderLink = $this->_objectManager->create('Razorpay\Magento\Model\OrderLink');
+                    $orderLink->setQuoteId($receipt_id)
+                            ->setRzpOrderId($order->id)
+                            ->save();
+                }
+
+                return $responseContent;
+
+            }else
+            {
+                return [
+                    'success' => false,
+                    'message' => "Razorpay Order not generated. Something went wrong",
+                ];
+            }
+        }
+        catch (\Razorpay\Api\Errors\Error $e)
+        {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        }
+        catch (\Exception $e)
+        {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        }
+    }
+}

--- a/Model/Resolver/SetRzpPaymentDetailsOnCart.php
+++ b/Model/Resolver/SetRzpPaymentDetailsOnCart.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Razorpay\Magento\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\QuoteGraphQl\Model\Cart\CheckCartCheckoutAllowance;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
+use Magento\QuoteGraphQl\Model\Cart\SetPaymentMethodOnCart as SetPaymentMethodOnCartModel;
+use Razorpay\Magento\Model\PaymentMethod;
+
+/**
+ * Mutation resolver for setting payment method for shopping cart
+ */
+class SetRzpPaymentDetailsOnCart implements ResolverInterface
+{
+    /**
+     * @var GetCartForUser
+     */
+    private $getCartForUser;
+
+    /**
+     * @var SetPaymentMethodOnCartModel
+     */
+    private $setPaymentMethodOnCart;
+
+    /**
+     * @var CheckCartCheckoutAllowance
+     */
+    private $checkCartCheckoutAllowance;
+
+    protected $_objectManager;
+
+
+
+    /**
+     * @param GetCartForUser $getCartForUser
+     * @param SetPaymentMethodOnCartModel $setPaymentMethodOnCart
+     * @param CheckCartCheckoutAllowance $checkCartCheckoutAllowance
+     */
+    public function __construct(
+        GetCartForUser $getCartForUser,
+        SetPaymentMethodOnCartModel $setPaymentMethodOnCart,
+        CheckCartCheckoutAllowance $checkCartCheckoutAllowance,
+        PaymentMethod $paymentMethod
+    ) {
+        $this->getCartForUser = $getCartForUser;
+        $this->setPaymentMethodOnCart = $setPaymentMethodOnCart;
+        $this->checkCartCheckoutAllowance = $checkCartCheckoutAllowance;
+
+        $this->rzp = $paymentMethod->rzp;
+
+        $this->_objectManager   = \Magento\Framework\App\ObjectManager::getInstance();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (empty($args['input']['cart_id'])) {
+            throw new GraphQlInputException(__('Required parameter "cart_id" is missing.'));
+        }
+        $maskedCartId = $args['input']['cart_id'];
+
+        if (empty($args['input']['rzp_payment_id'])) {
+            throw new GraphQlInputException(__('Required parameter "rzp_payment_id" is missing.'));
+        }
+        $rzp_payment_id = $args['input']['rzp_payment_id'];
+
+        if (empty($args['input']['rzp_order_id'])) {
+            throw new GraphQlInputException(__('Required parameter "rzp_order_id" is missing.'));
+        }
+        $rzp_order_id = $args['input']['rzp_order_id'];
+
+        $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
+        $cart = $this->getCartForUser->execute($maskedCartId, $context->getUserId(), $storeId);
+
+
+        try
+        {
+            //fetch order from API
+            $rzp_order_data = $this->rzp->order->fetch($rzp_order_id);
+
+            if($rzp_order_data->receipt !== $cart->getId())
+            {
+                throw new GraphQlInputException(__('Not a valid Razorpay orderID'));
+            }
+
+        }
+        catch(\Razorpay\Api\Errors\Error $e)
+        {
+           throw new GraphQlInputException(__('Razorpay Error: %1.', $e->getMessage()));
+        }
+
+        try
+        {
+            //save to razorpay orderLink            
+            $orderLinkCollection = $this->_objectManager->get('Razorpay\Magento\Model\OrderLink')
+                                                   ->getCollection()
+                                                   ->addFilter('quote_id', $cart->getId())
+                                                   ->getFirstItem();
+
+            $orderLinkData = $orderLinkCollection->getData();
+
+
+            if (empty($orderLinkData['entity_id']) === false)
+            {
+                $orderLinkCollection->setRzpPaymentId($rzp_payment_id)
+                                    ->setRzpOrderId($rzp_order_id)
+                                    ->save();
+            }
+            else
+            {
+                $orderLnik = $this->_objectManager->create('Razorpay\Magento\Model\OrderLink');
+                $orderLnik->setQuoteId($cart->getId())
+                          ->setRzpPaymentId($rzp_payment_id)
+                          ->setRzpOrderId($rzp_order_id)
+                          ->save();
+            }
+
+        }
+        catch (\Exception $e)
+        {
+            throw new GraphQlInputException(__('Razorpay Error: %1.', $e->getMessage()));
+        }
+
+        return [
+            'cart' => [
+                'model' => $cart,
+            ],
+        ];
+    }
+}

--- a/Model/Resolver/SetRzpPaymentDetailsOnCart.php
+++ b/Model/Resolver/SetRzpPaymentDetailsOnCart.php
@@ -99,7 +99,7 @@ class SetRzpPaymentDetailsOnCart implements ResolverInterface
 
         try
         {
-            //save to razorpay orderLink            
+            //save to razorpay orderLink
             $orderLinkCollection = $this->_objectManager->get('Razorpay\Magento\Model\OrderLink')
                                                    ->getCollection()
                                                    ->addFilter('quote_id', $cart->getId())

--- a/Model/Resolver/SetRzpPaymentDetailsOnCart.php
+++ b/Model/Resolver/SetRzpPaymentDetailsOnCart.php
@@ -62,20 +62,33 @@ class SetRzpPaymentDetailsOnCart implements ResolverInterface
      */
     public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
     {
-        if (empty($args['input']['cart_id'])) {
+        if (empty($args['input']['cart_id']))
+        {
             throw new GraphQlInputException(__('Required parameter "cart_id" is missing.'));
         }
+
         $maskedCartId = $args['input']['cart_id'];
 
-        if (empty($args['input']['rzp_payment_id'])) {
+        if (empty($args['input']['rzp_payment_id']))
+        {
             throw new GraphQlInputException(__('Required parameter "rzp_payment_id" is missing.'));
         }
+
         $rzp_payment_id = $args['input']['rzp_payment_id'];
 
-        if (empty($args['input']['rzp_order_id'])) {
+        if (empty($args['input']['rzp_order_id']))
+        {
             throw new GraphQlInputException(__('Required parameter "rzp_order_id" is missing.'));
         }
+
         $rzp_order_id = $args['input']['rzp_order_id'];
+
+        if (empty($args['input']['rzp_signature']))
+        {
+            throw new GraphQlInputException(__('Required parameter "rzp_signature" is missing.'));
+        }
+
+        $rzp_signature = $args['input']['rzp_signature'];
 
         $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
         $cart = $this->getCartForUser->execute($maskedCartId, $context->getUserId(), $storeId);
@@ -112,6 +125,7 @@ class SetRzpPaymentDetailsOnCart implements ResolverInterface
             {
                 $orderLinkCollection->setRzpPaymentId($rzp_payment_id)
                                     ->setRzpOrderId($rzp_order_id)
+                                    ->setRzpSignature($rzp_signature)
                                     ->save();
             }
             else
@@ -120,6 +134,7 @@ class SetRzpPaymentDetailsOnCart implements ResolverInterface
                 $orderLnik->setQuoteId($cart->getId())
                           ->setRzpPaymentId($rzp_payment_id)
                           ->setRzpOrderId($rzp_order_id)
+                          ->setRzpSignature($rzp_signature)
                           ->save();
             }
 

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -80,6 +80,15 @@ class UpgradeSchema implements  UpgradeSchemaInterface
                 ]
             )
             ->addColumn(
+                'rzp_order_amount',
+                Table::TYPE_INTEGER,
+                20,
+                [
+                    'nullable' => true,
+                    'comment'  => 'RZP order amount'
+                ]
+            )
+            ->addColumn(
                 'by_webhook',
                 Table::TYPE_BOOLEAN,
                 1,
@@ -140,7 +149,7 @@ class UpgradeSchema implements  UpgradeSchemaInterface
 
         $setup->getConnection()->createTable($table);
 
-        if (version_compare($context->getVersion(), '3.5.3', '>')) {
+        if (version_compare($context->getVersion(), '3.5.4', '<')) {
             $setup->getConnection()->addColumn(
                 $setup->getTable(OrderLink::TABLE_NAME),
                 'rzp_signature',
@@ -149,6 +158,17 @@ class UpgradeSchema implements  UpgradeSchemaInterface
                     'type'     => Table::TYPE_TEXT,
                     'length'   => 255,
                     'comment'  => 'RZP signature'
+                ]
+            );
+
+            $setup->getConnection()->addColumn(
+                $setup->getTable(OrderLink::TABLE_NAME),
+                'rzp_order_amount',
+                [
+                    'nullable' => true,
+                    'type'     => Table::TYPE_INTEGER,
+                    'length'   => 20,
+                    'comment'  => 'RZP order amount'
                 ]
             );
         }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -140,6 +140,19 @@ class UpgradeSchema implements  UpgradeSchemaInterface
 
         $setup->getConnection()->createTable($table);
 
+        if (version_compare($context->getVersion(), '3.5.3', '>')) {
+            $setup->getConnection()->addColumn(
+                $setup->getTable(OrderLink::TABLE_NAME),
+                'rzp_signature',
+                [
+                    'nullable' => true,
+                    'type'     => Table::TYPE_TEXT,
+                    'length'   => 255,
+                    'comment'  => 'RZP signature'
+                ]
+            );
+        }
+
         $setup->endSetup();
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -72,6 +72,14 @@ class UpgradeSchema implements  UpgradeSchemaInterface
                 ]
             )
             ->addColumn(
+                'rzp_signature',
+                Table::TYPE_TEXT,
+                225,
+                [
+                    'nullable' => true
+                ]
+            )
+            ->addColumn(
                 'by_webhook',
                 Table::TYPE_BOOLEAN,
                 1,

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,6 +5,7 @@
 	        <module name="Magento_Sales" />
 	        <module name="Magento_Payment" />
 	        <module name="Magento_Config" />
+	        <module name="Magento_GraphQl"/>
 	    </sequence>
 	</module>
 </config>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,14 @@
+type Mutation {
+	setRzpPaymentDetailsOnCart(input: SetRzpPaymentDetailsOnCartInput): SetRzpPaymentDetailsOnCartOutput @resolver(class: "Razorpay\\Magento\\Model\\Resolver\\SetRzpPaymentDetailsOnCart")
+}
+
+input SetRzpPaymentDetailsOnCartInput {
+	cart_id: String!	
+	rzp_payment_id: String!
+	rzp_order_id: String!
+}
+
+type SetRzpPaymentDetailsOnCartOutput {
+    cart: Cart!
+}
+

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,11 +1,22 @@
 type Mutation {
-	setRzpPaymentDetailsOnCart(input: SetRzpPaymentDetailsOnCartInput): SetRzpPaymentDetailsOnCartOutput @resolver(class: "Razorpay\\Magento\\Model\\Resolver\\SetRzpPaymentDetailsOnCart")
+	setRzpPaymentDetailsOnCart(input: SetRzpPaymentDetailsOnCartInput) : SetRzpPaymentDetailsOnCartOutput @resolver(class: "Razorpay\\Magento\\Model\\Resolver\\SetRzpPaymentDetailsOnCart")
+	placeRazorpayOrder (cart_id: String @doc(description: "cart_id to generate Razorpay Order ID.")) : RazorpayOrder @resolver( class: "Razorpay\\Magento\\Model\\Resolver\\PlaceRazorpayOrder") @doc(description: "Place Razorpay Order with cart amount and currency to generate RZP order ID.")
+}
+
+type RazorpayOrder {
+	success: Boolean!
+	rzp_order_id: String
+	order_quote_id: String
+	amount: String
+	currency: String
+	message: String
 }
 
 input SetRzpPaymentDetailsOnCartInput {
 	cart_id: String!
 	rzp_payment_id: String!
 	rzp_order_id: String!
+	rzp_signature: String!
 }
 
 type SetRzpPaymentDetailsOnCartOutput {

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -3,7 +3,7 @@ type Mutation {
 }
 
 input SetRzpPaymentDetailsOnCartInput {
-	cart_id: String!	
+	cart_id: String!
 	rzp_payment_id: String!
 	rzp_order_id: String!
 }


### PR DESCRIPTION
**Razorpay GraphQl Extension**

Order flow for placing Magento Order using razorpay as payment method with graphql

1. set Payment Method on Cart
```
mutation {
  setPaymentMethodOnCart(input: {
      cart_id: "{{cart_ID}}"
      payment_method: {
          code: "razorpay"
      }
  }) {
    cart {
      selected_payment_method {
        code
      }
    }
  }
}
```

2. Create Razorpay Order ID against the cart 
```
mutation {
  placeRazorpayOrder (
    cart_id: "{{cartid}}"
  ){
    success
    rzp_order_id
    order_quote_id
    amount
    currency
    message
  }
}
```

3. Use `rzp_order_id` and other details from step-2 and create from the Frontend/React/using razorpay's checkout.js , complete the payment and obtain razorpay_payment_id & razorpay_signature
  https://razorpay.com/docs/payment-gateway/web-integration/standard/

4. Save Razorpay Response Details against Cart after payment success 
```
mutation {
  setRzpPaymentDetailsOnCart (
    input: {
      cart_id: "{{cart_ID}}"
      rzp_payment_id: "{{RAZORPAY_PAYMENT_ID}}"
      rzp_order_id: "{{RAZORPAY_ORDER_ID}}"
      rzp_signature: "{{RAZORPAY_SIGNATURE}}"
    }
  ){
  cart{
    id
  }
  }
}
```
5. Finally Place Magento Order 
```
mutation {
  placeOrder(input: {cart_id: "{{cart_ID}}"}) {
    order {
      order_number
    }
  }
}
```
