### PR TITLE
Fix removal of webhook secret

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -30,7 +30,6 @@ class UpgradeSchema implements  UpgradeSchemaInterface
                  'payment/razorpay/order_status',
                  'payment/razorpay/webhook_wait_time',
                  'payment/razorpay/enable_webhook',
-                 'payment/razorpay/webhook_secret',
                  'payment/razorpay/webhook_events'
                 ]))
             {


### PR DESCRIPTION
Removed `webhook_secret` path from array to avoid deleting webhook secret value from database
