### PR TITLE
Remove genesis.yml workflow file

### DIFF
--- a/.github/workflows/genesis.yml
+++ b/.github/workflows/genesis.yml
@@ -1,8 +1,0 @@
-name: Quality Checks
-on:
-  schedule:
-    - cron: "0 17 * * *"
-jobs:
-  Analysis:
-    uses: razorpay/genesis/.github/workflows/quality-checks.yml@master
-    secrets: inherit


### PR DESCRIPTION
## Summary
This PR removes the `genesis.yml` workflow file from the repository.

## Changes
- Deleted `.github/workflows/genesis.yml`

## Reason
As part of the workflow cleanup initiative, removing the legacy genesis workflow file.

## Checklist
- [x] File deleted successfully
- [ ] PR reviewed and approved
- [ ] Changes deployed and tested