### PR TITLE
fix: Magic Checkout frozen modal when cart has discounts [ISS-1875890]

### DIFF
--- a/Controller/OneClick/PlaceOrder.php
+++ b/Controller/OneClick/PlaceOrder.php
@@ -1,0 +1,437 @@
+<?php
+
+namespace Razorpay\Magento\Controller\OneClick;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Quote\Api\CartManagementInterface;
+use Magento\Quote\Model\QuoteFactory;
+use Razorpay\Magento\Model\QuoteBuilderFactory;
+use Razorpay\Magento\Model\QuoteBuilder;
+use Magento\Framework\Pricing\Helper\Data;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+use Razorpay\Magento\Model\PaymentMethod;
+use Razorpay\Magento\Model\Config as RazorpayConfig;
+use Razorpay\Api\Api;
+use Magento\Framework\App\Request\Http;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Quote\Model\Quote\Item;
+use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Quote\Model\ResourceModel\Quote\QuoteIdMask as QuoteIdMaskResourceModel;
+use Magento\Checkout\Model\Session;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\SalesSequence\Model\Manager as SequenceManager;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableProduct;
+use Magento\GroupedProduct\Model\Product\Type\Grouped as GroupedProduct;
+
+class PlaceOrder extends Action
+{
+    /**
+     * @var Http
+     */
+    protected $request;
+
+    /**
+     * @var JsonFactory
+     */
+    protected $resultJsonFactory;
+
+    /**
+     * @var CartManagementInterface
+     */
+    protected $cartManagement;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    protected $productRepository;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    protected $rzp;
+
+    /**
+     * @var QuoteBuilderFactory
+     */
+    protected $quoteBuilderFactory;
+
+    protected $maskedQuoteIdInterface;
+
+    private QuoteIdMaskFactory $quoteIdMaskFactory;
+
+    private QuoteIdMaskResourceModel $quoteIdMaskResourceModel;
+
+    protected $storeManager;
+
+    protected $cart;
+
+    protected $checkoutSession;
+
+    protected $resourceConnection;
+
+    protected $sequenceManager;
+
+    protected $quoteFactory;
+
+    protected $config;
+
+    protected $configurableProduct;
+    protected $groupedProduct;
+    protected $customerSession;
+
+    const QUOTE_LINKED_RAZORPAY_ORDER_ID = "quote_linked_razorpay_order_id";
+
+    /**
+     * PlaceOrder constructor.
+     * @param Http $request
+     * @param Context $context
+     * @param JsonFactory $jsonFactory
+     * @param CartManagementInterface $cartManagement
+     * @param RazorpayConfig $config
+     * @param PaymentMethod $paymentMethod
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param QuoteBuilderFactory $quoteBuilderFactory
+     * @param ProductRepositoryInterface $productRepository
+     */
+    public function __construct(
+        Context                                   $context,
+        Http                                      $request,
+        JsonFactory                               $jsonFactory,
+        CartManagementInterface                   $cartManagement,
+        PaymentMethod                             $paymentMethod,
+        RazorpayConfig                            $config,
+        \Psr\Log\LoggerInterface                  $logger,
+        QuoteBuilderFactory                       $quoteBuilderFactory,
+        ProductRepositoryInterface                $productRepository,
+        QuoteIdToMaskedQuoteIdInterface           $maskedQuoteIdInterface,
+        QuoteIdMaskFactory                        $quoteIdMaskFactory,
+        QuoteIdMaskResourceModel                  $quoteIdMaskResourceModel,
+        StoreManagerInterface                     $storeManager,
+        \Magento\Checkout\Model\Cart              $cart,
+        Session                                   $checkoutSession,
+        \Magento\Framework\App\ResourceConnection $resourceConnection,
+        SequenceManager                           $sequenceManager,
+        QuoteFactory                              $quoteFactory,
+        ConfigurableProduct                       $configurableProduct,
+        GroupedProduct                            $groupedProduct,
+        CustomerSession                           $customerSession
+    )
+    {
+        parent::__construct($context);
+        $this->request = $request;
+        $this->resultJsonFactory = $jsonFactory;
+        $this->cartManagement = $cartManagement;
+        $this->config = $config;
+        $this->rzp = $paymentMethod->setAndGetRzpApiInstance();
+        $this->logger = $logger;
+        $this->quoteBuilderFactory = $quoteBuilderFactory;
+        $this->productRepository = $productRepository;
+        $this->maskedQuoteIdInterface = $maskedQuoteIdInterface;
+        $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->quoteIdMaskResourceModel = $quoteIdMaskResourceModel;
+        $this->storeManager = $storeManager;
+        $this->cart = $cart;
+        $this->checkoutSession = $checkoutSession;
+        $this->resourceConnection = $resourceConnection;
+        $this->sequenceManager = $sequenceManager;
+        $this->quoteFactory = $quoteFactory;
+        $this->configurableProduct = $configurableProduct;
+        $this->groupedProduct = $groupedProduct;
+        $this->customerSession = $customerSession;
+    }
+
+    public function execute()
+    {
+        $params = $this->request->getParams();
+
+        if (isset($params['page']) && $params['page'] == 'cart') {
+            $cartItems = $this->cart->getQuote()->getAllVisibleItems();
+            $quoteId = $this->cart->getQuote()->getId();
+            $totals = $this->cart->getQuote()->getTotals();
+
+            $quote = $this->checkoutSession->getQuote();
+            $customerId = $quote->getCustomerId();
+
+            // Set customer as guest to update the quote during checkout journey.
+            if ($customerId) {
+                $this->logger->info('graphQL: customer: ' . json_encode($customerId));
+
+                $connection = $this->resourceConnection->getConnection();
+                $tableName = $this->resourceConnection->getTableName('quote');
+
+                $quote->setCustomerId(null);
+
+                $quote->save();
+
+                $connection->update($tableName, ['customer_id' => null, 'customer_is_guest' => 1], ['entity_id = ?' => $quoteId]);
+
+                $tableQuoteAddressName = $this->resourceConnection->getTableName('quote_address');
+
+                $connection->update($tableQuoteAddressName, ['customer_id' => null, 'customer_address_id' => null], ['quote_id = ?' => $quoteId]);
+
+            }
+        } else {
+            /** @var QuoteBuilder $quoteBuilder */
+            $quoteBuilder = $this->quoteBuilderFactory->create();
+            $quote = $quoteBuilder->createQuote();
+            $quoteId = $quote->getId();
+            $quote = $this->quoteFactory->create()->load($quoteId);
+            $totals = $quote->getTotals();
+            $quote->collectTotals();
+            $cartItems = $quote->getAllVisibleItems();
+        }
+
+        $resultJson = $this->resultJsonFactory->create();
+
+        try {
+            $maskedId = $this->maskedQuoteIdInterface->execute($quoteId);
+
+            if ($maskedId === '') {
+                $quoteIdMask = $this->quoteIdMaskFactory->create();
+                $quoteIdMask->setQuoteId($quoteId);
+                $this->quoteIdMaskResourceModel->save($quoteIdMask);
+                $maskedId = $this->maskedQuoteIdInterface->execute($quoteId);
+            }
+            $this->storeManager->getStore()->getBaseCurrencyCode();
+
+            $totalAmount = 0;
+            $lineItems = [];
+            $item = [];
+
+            foreach ($cartItems as $quoteItem) {
+                $category = [];
+
+                $store = $this->storeManager->getStore();
+                $productId = $quoteItem->getProductId();
+                $product = $this->productRepository->getById($productId);
+                $parentProductId = null;
+
+                // Check if the product is configurable
+                if ($product->getTypeId() == \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE) {
+                    $parentProductId = $this->configurableProduct->getParentIdsByChild($productId);
+                } elseif ($product->getTypeId() == \Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE) {
+                    $parentProductId = $this->groupedProduct->getParentIdsByChild($productId);
+                }
+
+                if ($parentProductId) {
+                    // Load the parent product by its ID with images
+                    $parentProduct = $this->productRepository->getById($parentProductId[0], false, $quote->getStoreId(), true);
+
+                    // Get the parent product image URL
+                    $productImageUrl = $parentProduct->getImageUrl();
+                } else {
+                    $productImageUrl = $store->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA) . 'catalog/product' . $product->getImage();
+                }
+
+                $imagewidth=200;
+                $imageheight=200;
+                $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+                $imageHelper  = $objectManager->get('\Magento\Catalog\Helper\Image');
+                $productImageUrl = $imageHelper->init($product, 'product_page_image_small')->setImageFile($product->getFile())->resize($imagewidth, $imageheight)->getUrl();
+
+                $productUrl = $product->getProductUrl();
+
+                $offerPrice = (int) round($quoteItem->getPrice() * 100);
+                // Check if the item has applied discounts
+                if ($quoteItem->getDiscountAmount()) {
+                    // Get the discount amount applied to the item
+                    $discountAmount = abs($quoteItem->getDiscountAmount() / (int)$quoteItem->getQty());
+
+                    $offerPrice = (int) round(($quoteItem->getPrice() - $discountAmount) * 100);
+                }
+
+                $categoriesIds = $product->getCategoryIds(); /*will return category ids array*/
+                foreach($categoriesIds as $categoryId){
+
+                    $cat = $objectManager->create('Magento\Catalog\Model\Category')->load($categoryId);
+                    $catName = $cat->getName();
+                    $category['category'][] = $catName;
+                }
+                $item = array_merge($item, $category);
+
+                $storeName = [
+                    'affiliation' => $this->storeManager->getStore()->getName(),
+                ];
+                $item = array_merge($item, $storeName);
+
+                $lineItem = [
+                    'type' => 'e-commerce',
+                    'sku' => $quoteItem->getSku(),
+                    'variant_id' => $quoteItem->getProductId(),
+                    'price' => (int) round($quoteItem->getPrice() * 100),
+                    'offer_price' => $offerPrice,
+                    'tax_amount' => 0,
+                    'quantity' => (int)$quoteItem->getQty(),
+                    'name' => substr($quoteItem->getName(), 0,125),
+                    'description' => substr($quoteItem->getName(), 0, 125),
+                    'image_url' => $productImageUrl,
+                    'product_url' => $productUrl,
+                ];
+
+                $lineItems[] = $lineItem;
+
+                $item = array_merge($item, $lineItem);
+
+                $items[] = $item;
+            }
+            $totalAmount = (int) round($quote->getSubtotalWithDiscount() * 100);
+
+        } catch (LocalizedException $e) {
+            return $resultJson->setData([
+                'status' => 'error',
+                'message' => __($e->getMessage()),
+            ]);
+        } catch (\Exception $e) {
+            return $resultJson->setData([
+                'status' => 'error',
+                'message' => __('An error occurred on the server. Please try again.'),
+            ]);
+        }
+
+        $storeScope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
+
+        $paymentAction = $this->config->getPaymentAction();
+        $paymentCapture = 1;
+        if ($paymentAction === 'authorize') {
+            $paymentCapture = 0;
+        }
+        $rzpKey = $this->config->getKeyId();
+        $merchantName = $this->config->getMerchantNameOverride();
+        $allowCouponApplication = $this->config->getMerchantCouponApplication();
+
+        $this->getLastOrderId($quote);
+
+        $orderNotes = [
+            'cart_mask_id' => $maskedId,
+            'cart_id' => $quoteId,
+            'merchant_order_id' => (string)$quote->getReservedOrderId() ?? 'order pending'
+        ];
+        $customerEmail = $this->getCustomerEmailFromQuote();
+
+        if($customerEmail !== false)
+        {
+            $customerEmailNotes = [
+                'website_logged_in_email' => $customerEmail
+            ];
+            $orderNotes = array_merge($orderNotes, $customerEmailNotes);
+        }
+
+        try {
+            $razorpay_order = $this->rzp->order->create([
+                'amount' => $totalAmount,
+                'receipt' => (string)$quote->getReservedOrderId() ?? 'order pending',
+                'currency' => $this->storeManager->getStore()->getBaseCurrencyCode(),
+                'payment_capture' => $paymentCapture,
+                'app_offer' => 0,
+                'notes' => $orderNotes,
+                'line_items_total' => $totalAmount,
+                'line_items' => $lineItems
+            ]);
+        } catch (\Razorpay\Api\Errors\Error $e) {
+            $this->logger->critical('graphQL: Razorpay API error: ' . $e->getMessage());
+            return $resultJson->setData([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ]);
+        } catch (\Exception $e) {
+            $this->logger->critical('graphQL: Order create exception: ' . $e->getMessage());
+            return $resultJson->setData([
+                'status' => 'error',
+                'message' => __('An error occurred while creating your order. Please try again.'),
+            ]);
+        }
+
+        if (null !== $razorpay_order && !empty($razorpay_order->id)) {
+            $this->logger->info('graphQL: Razorpay Order ID: ' . $razorpay_order->id);
+            $catalogRzpKey = static::QUOTE_LINKED_RAZORPAY_ORDER_ID.'_'.$maskedId;
+            $this->logger->info('graphQL: Razorpay Order ID stored catalogKey: ' . $catalogRzpKey);
+
+            $this->checkoutSession->setData($catalogRzpKey, $razorpay_order->id);
+
+            $result = [
+                'status' => 'success',
+                'rzp_key_id' => $rzpKey,
+                'allow_coupon_application' => $allowCouponApplication == 1 ? true : false,
+                'rzp_order_id' => $razorpay_order->id,
+                'items' => $items,
+                'message' => 'Razorpay Order created successfully'
+            ];
+
+            $orderLink = $this->_objectManager->get('Razorpay\Magento\Model\OrderLink')
+                ->getCollection()
+                ->addFilter('order_id', $quote->getReservedOrderId())
+                ->getFirstItem();
+
+            $orderLink->setRzpOrderId($razorpay_order->id)
+                ->setOrderId($quote->getReservedOrderId())
+                ->save();
+        } else {
+            $this->logger->critical('graphQL: Razorpay Order not generated. Something went wrong');
+
+            $result = [
+                'status' => 'error',
+                'message' => "Razorpay Order not generated. Something went wrong",
+            ];
+        }
+
+        return $resultJson->setData($result);
+
+    }
+
+    public function getCustomerEmailFromQuote()
+    {
+        // Check if customer is logged in
+        if ($this->customerSession->isLoggedIn()) {
+            // Get active quote associated with customer session
+            $customerEmail = $this->customerSession->getCustomer()->getEmail();
+
+            // Check if customer email is available
+            if ($customerEmail) {
+                return $customerEmail;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    public function getLastOrderId($quote)
+    {
+        try {
+            $sequence = $this->sequenceManager->getSequence(
+                \Magento\Sales\Model\Order::ENTITY,
+                $quote->getStoreId()
+            );
+
+            // Generate a reserved order ID using the sequence
+            $reservedOrderId = $sequence->getNextValue();
+
+            // Check if the order and quote are available
+            if ($reservedOrderId) {
+                // Save the order ID in the quote for future reference
+                $quote->setReservedOrderId($reservedOrderId);
+            }
+
+            $quote->save();
+
+            return $reservedOrderId;
+        } catch (\Exception $e) {
+            // Handle exception if needed
+            return 'order pending';
+        }
+    }
+}

--- a/view/frontend/web/js/magic-cart.js
+++ b/view/frontend/web/js/magic-cart.js
@@ -1,0 +1,310 @@
+define([
+  "jquery",
+  "mage/translate",
+  "Magento_Ui/js/modal/alert",
+  "Magento_Checkout/js/model/full-screen-loader",
+  "mage/url",
+  "Razorpay_Magento/js/analytics",
+  "underscore",
+  "mage/cookies",
+], function ($, $t, alert, fullScreenLoader, url, analytics, _) {
+  "use strict";
+
+  $.widget("pmclain.oneClickButton", {
+    options: {
+      addToFormSelector: "#cart-occ-div",
+      actionSelector: ".action",
+      buttonTemplateSelector: "#cart-occ-div",
+      buttonSelector: "#cart-occ-template",
+      confirmationSelector: "#one-click-confirmation",
+      spinnerId: "magic-razorpay-spinner",
+    },
+
+    cookie: "occ_status",
+    cookieEnabled: "enabled",
+    cookieDisabled: "disabled",
+
+    _create: function () {
+      this._initButton();
+    },
+
+    _initButton: function () {
+      var self = this;
+
+      switch ($.mage.cookies.get(this.cookie)) {
+        case this.cookieEnabled:
+          this._createButton();
+          break;
+        case this.cookieDisabled:
+          break;
+        default:
+          self._createButton();
+      }
+    },
+
+    initObservable: function () {
+      var self = this._super(); //Resolves UI Error on Checkout
+
+      $.getScript(
+        "https://checkout.razorpay.com/v1/magic-checkout.js",
+        function () {
+          self.razorpayDataFrameLoaded = true;
+        },
+      );
+
+      return self;
+    },
+
+    _createButton: function () {
+      var button = $(this.options.buttonTemplateSelector).html();
+      this._bind();
+    },
+
+    _bind: function () {
+      var self = this;
+      this._parent()
+        .find(self.options.buttonSelector)
+        .on("click touch", function () {
+          if(window.magicConfig.isMagicEnabled == true){
+            self._cartCheckout();
+          }else{
+            var checkoutURL = url.build('checkout', {})
+            window.location.href = checkoutURL;
+          }
+        });
+    },
+
+    _parent: function () {
+      return $(this.options.addToFormSelector);
+    },
+
+    _cartCheckout: function () {
+      var self = this;
+      self._disableButton();
+      self.showRazorpayLoader(true);
+
+      var placeOrder = url.build("razorpay/oneclick/placeorder", {});
+      $.ajax({
+        url: placeOrder,
+        data: { page: "cart" },
+        type: "POST",
+        dataType: "json",
+        success: function (data) {
+          if (data && data.status === "error") {
+            self.hideRazorpayLoader();
+            self.toggleLoader(false);
+            self._orderError(data.message || "An error occurred. Please try again.");
+            self.enableButton();
+            return;
+          }
+          self.renderIframe(data);
+        },
+        error: function (request) {
+          self.hideRazorpayLoader();
+          self.toggleLoader(false);
+          self._orderError(request);
+          self.enableButton();
+        },
+      });
+    },
+
+    orderSuccess: function (data) {
+      var self = this;
+      self.enableButton();
+
+      var completeOrder = url.build("razorpay/oneclick/completeorder", {});
+      $.ajax({
+        url: completeOrder,
+        data: data,
+        type: "POST",
+        dataType: "json",
+        success: function (data) {
+          self.toggleLoader(true);
+
+          if (analytics.MagicMxAnalytics.purchase) {
+            analytics.MagicMxAnalytics.purchase({
+              ...data,
+              merchantAnalyticsConfigs: {},
+            }).finally(() => {
+              continueRedirection();
+            });
+          } else {
+            continueRedirection();
+          }
+
+          function continueRedirection() {
+            var successUrl = url.build("checkout/onepage/success", {});
+            window.location.href = successUrl;
+          }
+        },
+        error: function (error) {
+          self.toggleLoader(false);
+          console.log("Payment complete fail");
+          var failureUrl = url.build("checkout/onepage/failure", {});
+          window.location.href = failureUrl;
+        },
+      });
+    },
+
+    abandonedCart: function (rzp_order_id) {
+      var self = this;
+
+      var abandonedQuote = url.build("razorpay/oneclick/abandonedQuote", {});
+      $.ajax({
+        url: abandonedQuote,
+        data: { rzp_order_id: rzp_order_id },
+        type: "POST",
+        dataType: "json",
+        success: function (data) {
+          console.log(data);
+        },
+        error: function (error) {
+          console.log("Payment complete fail");
+          console.log(error);
+        },
+      });
+    },
+
+    renderIframe: function (data) {
+      var self = this;
+      var rzp_order_id = data.rzp_order_id;
+
+      var options = {
+        key: data.rzp_key_id,
+        name: "",
+        amount: data.totalAmount,
+        one_click_checkout: true,
+        show_coupons: data.allow_coupon_application,
+        handler: function (data) {
+          console.log("data in handler", data);
+          self.toggleLoader(true);
+          self.orderSuccess(data);
+        },
+        order_id: data.rzp_order_id,
+        modal: {
+          ondismiss: function (data) {
+            self.abandonedCart(rzp_order_id);
+            self.enableButton();
+
+            //reset the cart
+            // self.resetCart(data);
+            // fullScreenLoader.stopLoader();
+            // self.isPaymentProcessing.reject("Payment Closed");
+            // self.isPlaceOrderActionAllowed(true);
+          },
+        },
+        notes: {},
+        // callback_url : self.options.callbackURL,
+        prefill: {
+          name: "",
+          contact: "",
+          email: "",
+        },
+        _: {
+          integration: "magento",
+          // integration_version: '',
+          // integration_parent_version: data.maze_version,
+          integration_type: "plugin",
+        },
+      };
+
+      // if (data.quote_currency !== 'INR')
+      // {
+      //     options.display_currency = data.quote_currency;
+      //     options.display_amount = data.quote_amount;
+      // }
+
+      this.rzp = new Razorpay(options);
+      this.rzp.on("mx-analytics", (eventData) => {
+        const enabledAnalyticsTools = {
+          ga4: window.gtag,
+        };
+
+        analytics.MagicMxAnalytics?.[eventData.event]?.(
+          {
+            ...eventData,
+          },
+          data,
+          enabledAnalyticsTools,
+        );
+      });
+      self.toggleLoader(false);
+      this.rzp.open();
+    },
+
+    _orderError: function (request) {
+      this.enableButton();
+    },
+
+    _disableButton: function () {
+      var button = this._parent().find(this.options.buttonTemplateSelector);
+      button.addClass("disabled");
+    },
+
+    enableButton: function () {
+      var button = this._parent().find(this.options.buttonTemplateSelector);
+      button.removeClass("disabled");
+    },
+
+    hide: function () {
+      document.getElementById(this.options.spinnerId)?.remove();
+      // unblockPageScroll();
+    },
+
+    show: function () {
+      if (this.isVisible()) {
+        return;
+      }
+      document.body.appendChild(this.createTemplate(this.options.spinnerId));
+
+      // blockPageScroll();
+    },
+
+    isVisible: function () {
+      return document.getElementById(this.options.spinnerId) !== null;
+    },
+
+    createTemplate: function (id) {
+      const templateStr = `
+              <div id="${id}" style="position: fixed; top: 0; left: 0; z-index: 2147483647; width: 100%; height: 100%; background: rgb(0,0,0); opacity: 0.4;">
+              <style>
+                @keyframes rotate { 0% { transform: rotate(0); } 100% { transform: rotate(360deg); } }
+                #${id}::after {
+                  content: "";
+                  --length: 80px;
+                  position: absolute;
+                  width: var(--length);
+                  height: var(--length);
+                  left: calc(50% - var(--length) / 2);
+                  top: calc(50% - var(--length) / 2);
+                  border-radius: 50%;
+                  border: 4px solid;
+                  border-color: rgb(59, 124, 245) transparent rgb(59, 124, 245) rgb(59, 124, 245) !important;
+                  animation: 1s linear 0s infinite normal none running rotate;
+                  box-sizing: border-box;
+                }
+               </style>
+              </div>`;
+
+      return document.createRange().createContextualFragment(templateStr);
+    },
+
+    toggleLoader: function (flag) {
+      var self = this;
+
+      flag ? self.show() : self.hide();
+    },
+    showRazorpayLoader: function () {
+      if (typeof window.Razorpay?.showLoader === "function") {
+        window.Razorpay.showLoader?.();
+      }
+    },
+    hideRazorpayLoader: function () {
+      if (typeof window.Razorpay?.hideLoader === "function") {
+        window.Razorpay.hideLoader?.();
+      }
+    },
+  });
+
+  return $.pmclain.oneClickButton;
+});


### PR DESCRIPTION
## Summary

- **Bug 1 (PlaceOrder.php):** All paise amounts now use `(int) round(...)` to prevent fractional `offer_price` values being sent to the Razorpay Order API
- **Bug 2 (PlaceOrder.php):** `rzp->order->create()` is now wrapped in a dedicated try/catch, returning a JSON error response instead of an unhandled HTTP 500 HTML page
- **Bug 3 (magic-cart.js):** Added `hideRazorpayLoader()` in both the AJAX `error` callback and the `success` callback when `data.status === "error"`, so the SDK overlay is dismissed on failure instead of freezing permanently

## Root cause

Merchant: Art Lounge India (`artlounge.in`) | MID: `QdtT2XgfPGPjTQ` | ISS-1875890

The issue is in the line item building logic in `PlaceOrder.php`:

```php
if ($quoteItem->getDiscountAmount()) {
    $discountAmount = abs($quoteItem->getDiscountAmount() / (int)$quoteItem->getQty());
    $offerPrice = ($quoteItem->getPrice() - $discountAmount) * 100;
}
```

`getDiscountAmount()` returns the **total row discount** (e.g. ₹726.29 for all 3 units). Dividing by `qty=3` produces a fractional per-unit discount of ₹242.0966..., which when subtracted from the unit price and multiplied by 100 yields a non-integer `offer_price`:

```
₹726.29 ÷ qty 3 = ₹242.0966...
offer_price = (2995 - 242.0966...) × 100 = 263185.666... ← float, API rejects
```

This is the exact request that reached PG router and failed:

```json
{
  "line_items": [{
    "sku": "0010200",
    "price": 299500,
    "offer_price": 263185.66666667,
    "quantity": 3
  }]
}
```

The Razorpay Order API rejects this with `"The amount must be an integer"`, causing `PlaceOrder.php` to fail on `rzp->order->create()`. Because the exception was unhandled, it returned an HTTP 500 HTML response instead of JSON. The JS error handler received a non-JSON response, could not dismiss the SDK overlay, and left the customer on a permanently frozen loading screen.

**Fix:** Wrap all paise calculations with `(int) round(...)` so fractional paise are always rounded to the nearest integer before being sent to the API.

## Test plan

- [ ] Add product (SKU: `0010200`) to cart with qty=3 on artlounge.in — total discount ₹726.29 should apply (per-unit ₹242.0966...)
- [ ] Click "Checkout Now" — Magic Checkout modal should open successfully (no freeze)
- [ ] Verify `offer_price` in the order create payload is an integer (`263186`)
- [ ] Test with qty=2 (per-unit ₹363.145) — should also work
- [ ] Simulate an API error — verify modal closes and button re-enables with no freeze

🤖 Generated with [Claude Code](https://claude.com/claude-code)