### PR TITLE
Fix SKU length by adding 128-char limit

### DIFF
--- a/Controller/Payment/Order.php
+++ b/Controller/Payment/Order.php
@@ -49,6 +49,7 @@ class Order extends \Razorpay\Magento\Controller\BaseController
     private const MAX_DEVICE_ID_LENGTH       = 255;
     private const MAX_USER_AGENT_LENGTH      = 512;
     private const MAX_LINE_ITEM_NAME_LENGTH  = 125;
+    private const MAX_LINE_ITEM_SKU_LENGTH   = 128;
 
     protected $trackPluginInstrumentation;
 
@@ -658,9 +659,11 @@ class Order extends \Razorpay\Magento\Controller\BaseController
             $offerPrice = max(0, $price - $discount);
             $name       = substr((string)$item->getName(), 0, self::MAX_LINE_ITEM_NAME_LENGTH);
 
+            $sku = substr((string)$item->getSku(), 0, self::MAX_LINE_ITEM_SKU_LENGTH);
+
             $lineItems[] = [
                 'type'        => 'e-commerce',
-                'sku'         => (string)$item->getSku(),
+                'sku'         => $sku,
                 'variant_id'  => (string)$item->getProductId(),
                 'price'       => $price,
                 'offer_price' => $offerPrice,


### PR DESCRIPTION
## Summary

Truncate `line_items[].sku` to **128 characters** in `Order.php::buildLineItems()` before sending the payload to Razorpay's Order Creation API.

## Problem

Merchants with configurable or bundle product SKUs longer than **128 characters** are unable to complete checkout.

The Razorpay API returns:

```json
{
  "message": "sku: the length must be no more than 128.",
  "parameters": []
}
```

Razorpay's `order.create` API validates the length of `line_items[].sku` when the full Magic Checkout payload is sent, including:

* `line_items`
* `line_items_total`
* `customer_details`
* `shipping_fee`

Since order creation is handled through a **single API request**, one SKU exceeding the allowed length causes the entire order creation request to fail, blocking checkout for the merchant.

Magento's `sales_order_item.sku` column supports values up to **255 characters**, so SKUs longer than 128 characters are a valid and reachable state for merchants.

## Root Cause

`buildLineItems()` already truncates the product name to meet the API limit:

```php
$name = substr(
    (string) $item->getName(),
    0,
    self::MAX_LINE_ITEM_NAME_LENGTH
); // 125 characters
```

However, the SKU was being sent without any length restriction:

```php
'sku' => (string) $item->getSku(),
```

As a result, SKUs longer than Razorpay's API limit of **128 characters** caused the order creation API to reject the request.

## Fix

Truncate the SKU to **128 characters** before adding it to the `line_items` payload:

```php
$sku = substr(
    (string) $item->getSku(),
    0,
    self::MAX_LINE_ITEM_SKU_LENGTH
);
```

This ensures that all SKUs sent to Razorpay comply with the API's maximum length constraint while preserving the original SKU in Magento.

## Testing

Verified that:

* SKUs ≤ 128 characters are sent unchanged.
* SKUs > 128 characters are truncated to 128 characters.
* Orders with long configurable/bundle product SKUs can proceed through checkout.
* Existing checkout flows continue to work as expected.
