### PR TITLE
chore: add servicetree.yaml manifest

### DIFF
--- a/servicetree.yaml
+++ b/servicetree.yaml
@@ -1,0 +1,37 @@
+service: razorpay-magento  # required, canonical slug — immutable once registered
+displayName: "Razorpay for Magento"  # required, human-readable name — README title "## Razorpay Payment Extension for Magento"; matches the sibling plugin naming already in the registry ("Razorpay for WooCommerce")
+description: "The official Razorpay payment extension for Magento: it renders Razorpay Checkout inside the merchant's Magento store so Indian merchants can accept Credit Cards, Debit Cards, Net Banking, Wallets and EMI without redirecting away from the site."  # required, one-sentence description of what the service does — README ("This extension utilizes Razorpay API and provides seamless integration with Magento, allowing payments for Indian merchants via Credit Cards, Debit Cards, Net Banking, Wallets and EMI without redirecting away from the magento site")
+type: library  # required, one of: service | worker | cron | library | pipeline — a distributable PHP plugin (38 php files, Magento module enable/install instructions) that runs inside the merchant's Magento install; no Dockerfile, helm chart, Spinnaker pipeline or alert ruleset. Same shape as razorpay-woocommerce, which the registry types library · retype after the serviceTypes enum widens: sdk
+tier: T1  # required, one of: T0 | T1 | T2 | T3 — a broken release breaks checkout for every Magento merchant that upgrades, even though Razorpay operates no runtime for it; same tier as the already-registered razorpay-woocommerce (T1)
+lifecycle: live  # optional, one of: incubating | live | deprecated | retired (default: live) — actively maintained plugin (last push 2026-08-12) with current installation instructions
+
+domain: razorpay1/plugins  # required, two-level domain/subgroup slug — family razorpay1 from the registry seed BU "SME Payments" (l1 razorpay1); area plugins from the seed group "PG (Plugins, Checkout)" (team "Partnerships") — the e-commerce plugin family
+
+owner:
+  team:  # required, owning team slug — TO FILL: this repo has no CODEOWNERS file, .github/repo_owners.json carries no team slug, and the GitHub repository-teams API is not readable with the current token; ask the POD lead for the owning GitHub team
+  em:  # name | @slack | email — TO FILL: DevRev runnable owner not found in SuccessFactors
+  org_group:  # SuccessFactors group of the EM — TO FILL: the declared owner has no SuccessFactors record, so the org tree cannot be resolved; ask the POD lead
+  org_sub_group:  # SuccessFactors sub-group of the EM — TO FILL: the declared owner has no SuccessFactors record; ask the POD lead
+  org_pod:  # SuccessFactors pod of the EM — TO FILL: the declared owner has no SuccessFactors record; ask the POD lead
+  pm:  # product manager — TO FILL: not derived on purpose; PMs own products across org boundaries. Ask the Partnerships / PG (Plugins, Checkout) POD lead.
+  overrides: []  # optional, region-scoped owner overrides — TO FILL only if some region is owned by a different team; each entry is a "region" code plus the owning "team" slug
+
+links:
+  repo: "https://github.com/razorpay/razorpay-magento"  # canonical GitHub repo URL
+  alerts_repo:  # this service's alert rules in razorpay/alert-rules — TO FILL: no matching ruleset found; add one in razorpay/alert-rules, then link the file here
+  slos:  # SLO definitions — TO FILL: no slo.yaml at this repo root and no sloth ruleset for it under razorpay/alert-rules/slo/prod (the two places SLOs are defined today); add one there and link it here
+  slack_channel:  # primary Slack channel for this service — TO FILL: no slack_candidates in the draft; the sibling plugin razorpay-woocommerce has its own channel (#woo-razorpay) — ask the Partnerships / PG (Plugins, Checkout) POD lead whether a magento channel exists or the plugins channel covers it
+  zenduty_policy:  # Zenduty policy/service name used for paging — TO FILL: the service-to-policy mapping is not in DevRev or alert-rules for this service; it lives in the external Zenduty policies sheet
+  escalation_l1:  # service EM — TO FILL: no owner could be resolved for this service
+  escalation_l2:  # EM's manager — TO FILL: the EM has no SuccessFactors record, so no manager chain is available
+  escalation_l3:  # manager's manager — TO FILL: the EM has no SuccessFactors record, so no manager chain is available
+  oncall_handle:  # Slack/PagerDuty oncall handle or usergroup — TO FILL: not set on the DevRev runnable
+  runbook:  # link to the incident runbook — TO FILL: no runbook directory for this service in razorpay/rzp-oncall-agent; add one or link the Google Doc / alpha.razorpay.com page
+  api_docs:  # API documentation — TO FILL: no swagger/openapi/proto found in the repo tree; link the API spec or Postman collection
+  dashboard:  # primary dashboard — TO FILL: the plugin runs in merchant Magento installs, so Razorpay has no runtime metrics for it; no Grafana hit and no alert rules (no vajra_link). If plugin-version adoption is tracked anywhere, link that instead
+  logs_and_traces: "https://razorpay-prod.app.coralogix.in/#/query-new/archive-logs"  # org-standard prod Coralogix — filter subsystem "razorpay-magento"
+  strategy_okr:  # TO FILL: link the FY strategy doc for the owning group.
+  risk_assessment:  # TO FILL: no .agents/skills/risk-assessment in this repo; add the per-repo risk-assessment skill
+  regions:  # per-region links — TO FILL: no prod region deployment found for this service in spinacode or alert-rules; add a block per geography once it ships
+
+dependencies: []  # optional, declared service dependencies — TO FILL: shape: - service: <slug> for internal deps, - vendor: <name> for external (gateways, banks)


### PR DESCRIPTION
Adds the Service Tree manifest (`servicetree.yaml`) to the repo root.

This manifest declares service ownership, tier, domain, and links for the Service Tree registry. Fields not yet sourced are left blank with inline comments.

Part of the Service Tree rollout.

Generated with Claude Code